### PR TITLE
Use pg.v3 and cleanup benchmarks to make them more fair.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,16 +3,17 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	gopg "github.com/go-pg/pg"
-	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/stdlib"
-	_ "github.com/lib/pq"
 	"io"
 	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/stdlib"
+	_ "github.com/lib/pq"
+	gopg "gopkg.in/pg.v3"
 )
 
 var selectPeopleJSONSQL = `


### PR DESCRIPTION
I fixed import path and added `person.LoadColumn` to make benchmark more fair for go-pg, because for go-pg you also measure time to decode data into struct. Also `BenchmarkPgSelectMultipleRowsAndDiscard` shows base time for go-pg without time required to decode the data (hopefully useful for others too).

Results
```
BenchmarkPgxNativeSelectSingleValue-4    	   20000	     94701 ns/op	     386 B/op	       8 allocs/op
BenchmarkPgxStdlibSelectSingleValue-4    	   10000	    101747 ns/op	     669 B/op	      19 allocs/op
BenchmarkPgSelectSingleValue-4           	   20000	     86623 ns/op	     160 B/op	       8 allocs/op
BenchmarkPqSelectSingleValue-4           	   10000	    105961 ns/op	     512 B/op	      16 allocs/op
BenchmarkRawSelectSingleValue-4          	   20000	     69230 ns/op	      36 B/op	       1 allocs/op
BenchmarkPgxNativeSelectSingleRow-4      	   10000	    100647 ns/op	     517 B/op	      10 allocs/op
BenchmarkPgxStdlibSelectSingleRow-4      	   10000	    120555 ns/op	    1282 B/op	      28 allocs/op
BenchmarkPgSelectSingleRow-4             	   10000	    108637 ns/op	     480 B/op	      16 allocs/op
BenchmarkPqSelectSingleRow-4             	   10000	    127799 ns/op	    1024 B/op	      30 allocs/op
BenchmarkRawSelectSingleRow-4            	   20000	     72871 ns/op	      36 B/op	       1 allocs/op
BenchmarkPgxNativeSelectMultipleRows-4   	    5000	    217770 ns/op	   12633 B/op	     135 allocs/op
BenchmarkPgxStdlibSelectMultipleRows-4   	    5000	    312234 ns/op	   19911 B/op	     344 allocs/op
BenchmarkPgSelectMultipleRows-4          	    5000	    358672 ns/op	   15081 B/op	     284 allocs/op
BenchmarkPgSelectMultipleRowsAndDiscard-4	   10000	    178411 ns/op	      48 B/op	       3 allocs/op
BenchmarkPqSelectMultipleRows-4          	    5000	    381593 ns/op	   19923 B/op	     442 allocs/op
BenchmarkRawSelectMultipleRows-4         	   10000	    102418 ns/op	      72 B/op	       2 allocs/op
```