### PR TITLE
Fix link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This tests the performance of [pgx native](https://github.com/jackc/pgx), [pgx
 through database/sql](https://github.com/jackc/pgx/tree/master/stdlib),
-[pq](https://github.com/lib/pq) through database/sql, [go-pg](github.com/go-
-pg/pg),  and theoretical maximum PostgreSQL performance. It always uses prepared
+[pq](https://github.com/lib/pq) through database/sql, [go-pg](https://github.com/go-pg/pg),
+and theoretical maximum PostgreSQL performance. It always uses prepared
 statements.
 
 ## Configuration


### PR DESCRIPTION
Fix go-pg link (it was broken because of space)