### PR TITLE
Port / SSL mode override via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ go_db_bench reads its configuration from the environment:
     PGUSER - default to OS user
     PGPASSWORD - defaults to empty string
     PGDATABASE - defaults to go_db_bench
+    PGSSLMODE - defaults to disable
 
 ## Core Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ states otherwise it always uses prepared statements.
 go_db_bench reads its configuration from the environment:
 
     PGHOST - defaults to localhost
+    PGPORT - defaults to 5432
     PGUSER - default to OS user
     PGPASSWORD - defaults to empty string
     PGDATABASE - defaults to go_db_bench

--- a/main.go
+++ b/main.go
@@ -194,7 +194,11 @@ func openPq(config *pgx.ConnConfig) (*sql.DB, error) {
 	options = append(options, fmt.Sprintf("port=%v", config.Port))
 	options = append(options, fmt.Sprintf("user=%s", config.User))
 	options = append(options, fmt.Sprintf("dbname=%s", config.Database))
-	options = append(options, "sslmode=disable")
+	if config.TLSConfig == nil {
+		options = append(options, "sslmode=disable")
+	} else {
+		options = append(options, "sslmode=require")
+	}
 	if config.Password != "" {
 		options = append(options, fmt.Sprintf("password=%s", config.Password))
 	}
@@ -218,6 +222,7 @@ func openPg(config pgx.ConnConfig) (*gopg.DB, error) {
 	options.User = config.User
 	options.Database = config.Database
 	options.Password = config.Password
+	options.TLSConfig = config.TLSConfig
 
 	return gopg.Connect(&options), nil
 }

--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func openPgxStdlib(config *pgxpool.Config) (*sql.DB, error) {
 func openPq(config *pgx.ConnConfig) (*sql.DB, error) {
 	var options []string
 	options = append(options, fmt.Sprintf("host=%s", config.Host))
+	options = append(options, fmt.Sprintf("port=%v", config.Port))
 	options = append(options, fmt.Sprintf("user=%s", config.User))
 	options = append(options, fmt.Sprintf("dbname=%s", config.Database))
 	options = append(options, "sslmode=disable")
@@ -204,7 +205,7 @@ func openPq(config *pgx.ConnConfig) (*sql.DB, error) {
 func openPg(config pgx.ConnConfig) (*gopg.DB, error) {
 	var options gopg.Options
 
-	options.Addr = config.Host
+	options.Addr = fmt.Sprintf("%s:%d", config.Host, config.Port)
 	_, err := os.Stat(options.Addr)
 	if err == nil {
 		options.Network = "unix"


### PR DESCRIPTION
Hi, 

Digital Ocean has a managed postgres offering that starts on both a non standard port and uses tls/sslmode by default. Added options to set or override both via environment variables